### PR TITLE
Release/changedetection accountsegments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,80 +1,111 @@
+# CHANGELOG
+
+## v0.1.20
+
+- [bugfix] Add account segments to outgoing group calls as `hull_segments` property
+- [bugfix] Add change detection to reduce the amount of outgoing data to segment.com
+- [maintenance] Update `manifest.json` and `readme.md` to reflect the changes
+
 ## v0.1.19
+
 - Add FLOW_CONTROL_SIZE and FLOW_CONTROL_IN env vars to control smart-notifier behavior
 
 ## v0.1.18
+
 - Add smart notifier endpoint
 
 ## v0.1.17
+
 - Don't write outgoing.user.skip if no writeKey
 
 ## v0.1.16
+
 - Use `timestamp` instead of `originalTimestamp` as `created_at` in tracks handler
 
 ## v0.1.15
+
 - hotfix account properties not sent in User when listed there
 - cleanup Settings Screen
 - change account, page and screen tracking defaults to `true`
 - add status checks
 
 ## v0.1.14
+
 - upgrade hull-node to v0.13.9
 
 ## v0.1.13
+
 - hotfix error
 
 ## v0.1.12
+
 - hotfix error reporting
 - upgrade hull-node to v0.12.8
 
 ## v0.1.11
+
 - add tooling for CircleCI v2
 - pass along the `event_id` as `message_id` so Segment can dedupe events
 
 ## v0.1.10
+
 - add support for outgoing group calls with account attributes
 
 ## v0.1.9
+
 - adds `active` claim only if active flag is set from segment context
 
 ## v0.1.8
+
 - set correct maxSize and maxTime values for notifHandler
 - adds `active` claim to identify and track handlers to activate fast-lane
 - reverts manifest.json settings definition to correct structure
 
 ## v0.1.7
+
 - upgrade hull@0.12.6
 
 ## v0.1.6
+
 - upgrade hull@0.12.2
 - upgrade documentation and settings structure
 
 ## v0.1.5
+
 - optionally use redis store for internal caching
 
 ## v0.1.4
+
 - set default ttl for caching
 
 ## v0.1.3
+
 - hotfix ignore filters on batch
 - hotfix public_id field
 
 ## v0.1.2
+
 - hotfix the wrong incoming track handler
 
 ## v0.1.1
+
 - logging messages updates - levels adjusted and added more ident info
 
 ## v0.1.0
+
 - hull-node upgraded to 0.11
 - accounts support - enabled via `handle_accounts` setting
 
 ## v0.0.4
+
 - standardize log messages
 - update Build & Test dependencies
 - adds self-hosted installation information
 
 ## v0.0.3
+
 - change logs format to JSON
 
 ## v0.0.2
+
 - set version of NodeJS to `6.10.0`

--- a/assets/readme.md
+++ b/assets/readme.md
@@ -39,6 +39,7 @@ The Segment Connector sends and receives events for all users unless you restric
 You can specify the attributes that are getting send to Segment along with each event in the section “Hull as Source” of the “Settings” tab. By default, only the list of segments a user belongs to are send to Segment:
 ![Determine attributes](./docs/hullassource02.png)
 While this setting does not affect your MTU count in Segment, you might want to limit the attributes to the ones the Destinations in Segment can handle. This ensures an efficient data flow with less overhead.
+Hull User Segments are automatically sent in every `identify` call as property `hull_segments`. The same applies to Account Segments, these are automatically sent as property `hull_segments` in `group` calls.
 
 ## Determine the events to send to Segment (Hull as Source)
 

--- a/manifest.json
+++ b/manifest.json
@@ -17,7 +17,7 @@
     }
   ],
   "readme" : "readme.md",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "deployment_settings":[
     {
       "name"       : "_selector",
@@ -61,7 +61,7 @@
     {
       "name": "synchronized_properties",
       "title": "Attributes to send in Users",
-      "description": "*By default, only `email` and `hull_segments` are sent to Segment.com in `analytics.identify()` calls*",
+      "description": "*By default, only `email` and `hull_segments` (User Segments) are sent to Segment.com in `analytics.identify()` calls*",
       "type": "array",
       "format": "trait",
       "items": {
@@ -72,7 +72,7 @@
     {
       "name": "synchronized_account_properties",
       "title": "Attributes to send in Accounts",
-      "description": "*By default, only `domain` is sent to Segment.com in `analytics.group()` calls*",
+      "description": "*By default, only `domain` and `hull_segments` (Account Segments) are sent to Segment.com in `analytics.group()` calls*",
       "type": "array",
       "format": "accountTrait",
       "items": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hull-segment",
   "description": "Install Segment in your site",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "homepage": "https://github.com/hull-ships/hull-segment",
   "license": "MIT",
   "main": "dist/ship.js",

--- a/server/update-user.js
+++ b/server/update-user.js
@@ -2,7 +2,7 @@ import _ from "lodash";
 
 export default function updateUserFactory(analyticsClient) {
   return function updateUser({ message = {} }, { ship = {}, hull = {}, ignoreFilters = false }) {
-    const { user = {}, segments = [], events = [], account_segments = [] } = message;
+    const { user = {}, segments = [], events = [], account_segments = [], changes = {} } = message;
     const account = message.account || user.account;
 
     // Empty payload ?
@@ -72,62 +72,73 @@ export default function updateUserFactory(analyticsClient) {
       return false;
     }
 
-    const segment_ids = _.map(segments, "id");
-    if (
-      !ignoreFilters &&
-      synchronized_segments.length > 0 && // Should we move to "Send no one by default ?"
-      !_.intersection(segment_ids, synchronized_segments).length
-      ) {
-      asUser.logger.info("outgoing.user.skip", { reason: "not matching any segment", segment_ids, traits });
-      return false;
-    }
+    const changedUserAttributes = _.keys(_.get(changes, "user", {}));
+    const changedAccountAttributes = _.keys(_.get(changes, "account", {}));
 
     const integrations = { Hull: false };
-
     const context = { active: false, ip: 0 };
+    let ret = false;
 
-    try {
-      // Add group if available
-      if (handle_groups && groupId && userId) {
-        context.groupId = groupId;
-        const groupTraits = _.reduce(user, (group, value, key) => {
-          const mk = key.match(/^traits_group\/(.*)/);
-          const groupKey = mk && mk[1];
-          if (groupKey && groupKey !== "id") {
-            group[groupKey] = value;
-          }
-          return group;
-        }, {});
-        // Add account segments
-        _.set(groupTraits, "hull_segments", _.map(account_segments, "name"));
-        if (!_.isEmpty(groupTraits)) {
-          asUser.logger.info("outgoing.group.success", { groupId, traits: groupTraits, context });
-          analytics.group({ groupId, anonymousId, userId, traits: groupTraits, context, integrations });
-        }
-      } else if (handle_accounts && accountId) {
-        const accountTraits = synchronized_account_properties
-          .map(k => k.replace(/^account\./, ""))
-          .reduce((props, prop) => {
-            props[prop.replace("/", "_")] = account[prop];
-            return props;
-          }, {});
-        // Add account segments
-        _.set(accountTraits, "hull_segments", _.map(account_segments, "name"));
-
-        if (!_.isEmpty(accountTraits)) {
-          hull.logger.debug("group.send", { groupId: accountId, traits: accountTraits, context });
-          analytics.group({ groupId: accountId, anonymousId, userId, traits: accountTraits, context, integrations });
-        }
-
-        asUser.account({ external_id: accountId }).logger.info("outgoing.account.success", { groupId: accountId, traits: accountTraits, context });
+    if (!_.isEmpty(_.get(changes, "segments", {})) ||
+        _.intersection(synchronized_properties, changedUserAttributes).length > 0 ||
+        !_.isEmpty(_.get(changes, "account_segments", {})) ||
+        _.intersection(synchronized_account_properties, changedAccountAttributes).length > 0) {
+      const segment_ids = _.map(segments, "id");
+      if (
+        !ignoreFilters &&
+        synchronized_segments.length > 0 && // Should we move to "Send no one by default ?"
+        !_.intersection(segment_ids, synchronized_segments).length
+        ) {
+        asUser.logger.info("outgoing.user.skip", { reason: "not matching any segment", segment_ids, traits });
+        return false;
       }
-    } catch (err) {
-      console.warn("Error processing group update", err);
+
+      try {
+        // Add group if available
+        if (handle_groups && groupId && userId) {
+          context.groupId = groupId;
+          const groupTraits = _.reduce(user, (group, value, key) => {
+            const mk = key.match(/^traits_group\/(.*)/);
+            const groupKey = mk && mk[1];
+            if (groupKey && groupKey !== "id") {
+              group[groupKey] = value;
+            }
+            return group;
+          }, {});
+          // Add account segments
+          _.set(groupTraits, "hull_segments", _.map(account_segments, "name"));
+          if (!_.isEmpty(groupTraits)) {
+            asUser.logger.info("outgoing.group.success", { groupId, traits: groupTraits, context });
+            analytics.group({ groupId, anonymousId, userId, traits: groupTraits, context, integrations });
+          }
+        } else if (handle_accounts && accountId) {
+          const accountTraits = synchronized_account_properties
+            .map(k => k.replace(/^account\./, ""))
+            .reduce((props, prop) => {
+              props[prop.replace("/", "_")] = account[prop];
+              return props;
+            }, {});
+          // Add account segments
+          _.set(accountTraits, "hull_segments", _.map(account_segments, "name"));
+
+          if (!_.isEmpty(accountTraits)) {
+            hull.logger.debug("group.send", { groupId: accountId, traits: accountTraits, context });
+            analytics.group({ groupId: accountId, anonymousId, userId, traits: accountTraits, context, integrations });
+          }
+
+          asUser.account({ external_id: accountId }).logger.info("outgoing.account.success", { groupId: accountId, traits: accountTraits, context });
+        }
+      } catch (err) {
+        console.warn("Error processing group update", err);
+      }
+
+      ret = analytics.identify({ anonymousId, userId, traits, context, integrations });
+      asUser.logger.info("outgoing.user.success", { userId, traits });
+    } else {
+      asUser.logger.info("outgoing.user.skip", { reason: "No changes detected that would require a synchronization to segment.com" });
+      ret = false;
     }
 
-
-    const ret = analytics.identify({ anonymousId, userId, traits, context, integrations });
-    asUser.logger.info("outgoing.user.success", { userId, traits });
 
     if (events && events.length > 0) {
       events.map((e) => {

--- a/server/update-user.js
+++ b/server/update-user.js
@@ -82,7 +82,8 @@ export default function updateUserFactory(analyticsClient) {
     if (!_.isEmpty(_.get(changes, "segments", {})) ||
         _.intersection(synchronized_properties, changedUserAttributes).length > 0 ||
         !_.isEmpty(_.get(changes, "account_segments", {})) ||
-        _.intersection(synchronized_account_properties, changedAccountAttributes).length > 0) {
+        _.intersection(synchronized_account_properties, changedAccountAttributes).length > 0 ||
+        ignoreFilters === true) {
       const segment_ids = _.map(segments, "id");
       if (
         !ignoreFilters &&

--- a/server/update-user.js
+++ b/server/update-user.js
@@ -2,7 +2,7 @@ import _ from "lodash";
 
 export default function updateUserFactory(analyticsClient) {
   return function updateUser({ message = {} }, { ship = {}, hull = {}, ignoreFilters = false }) {
-    const { user = {}, segments = [], events = [] } = message;
+    const { user = {}, segments = [], events = [], account_segments = [] } = message;
     const account = message.account || user.account;
 
     // Empty payload ?
@@ -98,6 +98,8 @@ export default function updateUserFactory(analyticsClient) {
           }
           return group;
         }, {});
+        // Add account segments
+        _.set(groupTraits, "hull_segments", _.map(account_segments, "name"));
         if (!_.isEmpty(groupTraits)) {
           asUser.logger.info("outgoing.group.success", { groupId, traits: groupTraits, context });
           analytics.group({ groupId, anonymousId, userId, traits: groupTraits, context, integrations });
@@ -109,6 +111,8 @@ export default function updateUserFactory(analyticsClient) {
             props[prop.replace("/", "_")] = account[prop];
             return props;
           }, {});
+        // Add account segments
+        _.set(accountTraits, "hull_segments", _.map(account_segments, "name"));
 
         if (!_.isEmpty(accountTraits)) {
           hull.logger.debug("group.send", { groupId: accountId, traits: accountTraits, context });

--- a/tests/segment-tests.js
+++ b/tests/segment-tests.js
@@ -174,7 +174,7 @@ describe("Segment Ship", () => {
             done();
           }, 10);
         });
-    });
+    }).timeout(90000);
     it("call Hull.track on page event", (done) => {
       sendRequest({ body: page, query: config })
         .expect({ message: "thanks" })
@@ -187,7 +187,7 @@ describe("Segment Ship", () => {
             done();
           }, 10);
         });
-    });
+    }).timeout(90000);
     it("should Hull.track on page event by default", (done) => {
       shipData = {
         settings: {}
@@ -202,7 +202,7 @@ describe("Segment Ship", () => {
             done();
           }, 10);
         });
-    });
+    }).timeout(90000);
     it("call Hull.track on screen event", (done) => {
       // const postSpy = sinon.spy();
       // const MockHull = mockHullFactory(postSpy, API_RESPONSES.screen);
@@ -229,7 +229,7 @@ describe("Segment Ship", () => {
             done();
           }, 10);
         });
-    });
+    }).timeout(90000);
 
     it("Ignores incoming userId if settings.ignore_segment_userId is true", (done) => {
       shipData = {


### PR DESCRIPTION
### Changes

- [bugfix] Add account segments to outgoing group calls as `hull_segments` property
- [bugfix] Add change detection to reduce the amount of outgoing data to segment.com
- [maintenance] Update `manifest.json` and `readme.md` to reflect the changes
