### PR TITLE
changed logic for filtering events to apply to user updates as well a…

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "nodemon": "^1.10.0",
     "sinon": "^1.17.4",
     "supertest": "^3.0.0",
+    "simple-mock": "^0.8.0",
     "updtr": "^1.0.0",
     "watch": "^1.0.2"
   }

--- a/tests/fixtures/index.js
+++ b/tests/fixtures/index.js
@@ -4,5 +4,6 @@ module.exports = {
   identify: require('./identify.json'),
   page: require('./page.json'),
   screen: require('./screen.json'),
-  track: require('./track.json')
+  track: require('./track.json'),
+  userUpdateEventPayload: require('./user-update-event-payload.json'),
 };

--- a/tests/fixtures/user-update-event-payload.json
+++ b/tests/fixtures/user-update-event-payload.json
@@ -1,0 +1,373 @@
+{
+    "notification_id": "cc156fd4-5150-4f1f-908f-63287beafe5d",
+    "configuration": {
+        "id": "5bbb8592ec9ecaa580002cff",
+        "organization": "ad793dc7.hullapp.io",
+        "secret": "7640d59e15c5959e599ef437e3ba248d"
+    },
+    "connector": {
+        "tags": [],
+        "source_url": "https://d9bb86b5.ngrok.io/",
+        "private_settings": {"synchronized_segments": [
+            "5ade25df4d257947aa001cd5"
+        ]},
+        "index": "https://d9bb86b5.ngrok.io/ship.js",
+        "name": "Tims Local Ngrok",
+        "extra": {},
+        "settings": {
+            "public_id_field": "external_id",
+            "handle_pages": true,
+            "handle_screens": true,
+            "handle_accounts": false,
+            "ignore_segment_userId": false,
+            "public_account_id_field": "external_id",
+            "handle_groups": false,
+            "write_key": "fakekey"
+        },
+        "type": "ship",
+        "manifest": {
+            "description": "Complete control over your customer data with Hull and Segment",
+            "tags": [
+                "incoming",
+                "outgoing",
+                "batch",
+                "oneColumn",
+                "smart-notifier"
+            ],
+            "private_settings": [
+                {
+                    "name": "sync_out_info",
+                    "title": "Hull ➞ Segment",
+                    "format": "title",
+                    "type": "string"
+                },
+                {
+                    "name": "synchronized_segments",
+                    "title": "Users to send",
+                    "description": "*By default all users are sent to Segment.com. If you specify segments, only those will be sent*",
+                    "type": "array",
+                    "format": "segment",
+                    "items": {
+                        "type": "string"
+                    },
+                    "default": []
+                },
+                {
+                    "name": "send_events",
+                    "title": "Events to send",
+                    "description": "*By Default, all events are sent to Segment.com as `analytics.track()` calls. If you specify events above, only those will be sent.*",
+                    "type": "array",
+                    "format": "event",
+                    "default": []
+                },
+                {
+                    "name": "synchronized_properties",
+                    "title": "Attributes to send in Users",
+                    "description": "*By default, only `email` and `hull_segments` (User Segments) are sent to Segment.com in `analytics.identify()` calls*",
+                    "type": "array",
+                    "format": "trait",
+                    "items": {
+                        "type": "string"
+                    },
+                    "default": [
+                        "email"
+                    ]
+                },
+                {
+                    "name": "synchronized_account_properties",
+                    "title": "Attributes to send in Accounts",
+                    "description": "*By default, only `domain` and `hull_segments` (Account Segments) are sent to Segment.com in `analytics.group()` calls*",
+                    "type": "array",
+                    "format": "accountTrait",
+                    "items": {
+                        "type": "string"
+                    },
+                    "default": [
+                        "domain"
+                    ]
+                },
+                {
+                    "name": "forward_events",
+                    "title": "Enable forwarding of events received from Segment.com",
+                    "description": "ONLY enable this feature when the Write Key is from a different workspace. Read the manual before making any changes; this can result in an endless loop of events.",
+                    "type": "boolean",
+                    "default": false
+                }
+            ],
+            "admin": "admin.html",
+            "index": "ship.js",
+            "tabs": [
+                {
+                    "title": "Credentials",
+                    "url": "admin.html",
+                    "size": "small",
+                    "editable": false
+                }
+            ],
+            "name": "Segment",
+            "settings": [
+                {
+                    "name": "write_key",
+                    "title": "Write Key to send data to Segment.com API",
+                    "description": "Find it under Settings > API Keys > Write Key in your Segment.com workspace.",
+                    "type": "string",
+                    "format": "text"
+                },
+                {
+                    "name": "public_id_field",
+                    "title": "User ID",
+                    "description": "Attribute to use as `userId` in the segment payload. Warning: This can affect your MTUs.",
+                    "type": "string",
+                    "enum": [
+                        "id",
+                        "external_id"
+                    ],
+                    "default": "external_id",
+                    "format": "hidden"
+                },
+                {
+                    "name": "sending_hero",
+                    "title": "Important Note",
+                    "headerTemplate": "**Users are only sent to segment.com when at least one identifier is present, this can be either the `External ID` or one or more `Anonymous IDs`.**",
+                    "format": "information",
+                    "type": "string"
+                },
+                {
+                    "name": "sync_in_info",
+                    "title": "Segment ➞ Hull",
+                    "format": "title",
+                    "type": "string"
+                },
+                {
+                    "name": "handle_pages",
+                    "title": "Handle Page Calls",
+                    "description": "Record whenever a user sees a page of your website.",
+                    "type": "boolean",
+                    "default": true
+                },
+                {
+                    "name": "handle_screens",
+                    "title": "Handle Screen Calls",
+                    "description": "Screen calls let you record whenever a user sees a screen on a mobile app.",
+                    "type": "boolean",
+                    "default": true
+                },
+                {
+                    "name": "handle_accounts",
+                    "title": "Handle Group Calls",
+                    "description": "Handle incoming group calls. Group calls associate an individual user with a group—be it a company, organization, account, project, team or whatever you come up with. A user can be in multiple groups in segment, however **Hull will handle only one group**. Consecutive group calls will overwrite the attributes in Hull. For further information, please read the Instructions.",
+                    "type": "boolean",
+                    "default": false
+                },
+                {
+                    "name": "ignore_segment_userId",
+                    "title": "Ignore User ID",
+                    "description": "Ignore `userId` received from segment.com, use the email or anonymousId as identifier instead.",
+                    "type": "boolean",
+                    "default": false,
+                    "format": "hidden"
+                },
+                {
+                    "name": "public_account_id_field",
+                    "title": "Public Account ID Field",
+                    "description": "Account field to use as the groupId for data sent to segment",
+                    "type": "string",
+                    "enum": [
+                        "id",
+                        "external_id"
+                    ],
+                    "default": "external_id",
+                    "format": "hidden"
+                },
+                {
+                    "name": "handle_groups",
+                    "title": "Handle Groups",
+                    "description": "Handle group attributes as user traits, prefixed with 'group/'",
+                    "type": "boolean",
+                    "default": false,
+                    "format": "hidden"
+                }
+            ],
+            "subscriptions": [
+                {
+                    "url": "/smart-notify"
+                }
+            ],
+            "ui": false,
+            "picture": "picture.png",
+            "readme": "readme.md",
+            "schedules": [
+                {
+                    "url": "/status",
+                    "type": "interval",
+                    "value": "5"
+                }
+            ],
+            "version": "0.1.20",
+            "resources": [],
+            "deployment_settings": [
+                {
+                    "name": "_selector",
+                    "default": "body",
+                    "type": "string",
+                    "format": "string"
+                },
+                {
+                    "name": "_placement",
+                    "default": "append",
+                    "type": "string",
+                    "format": "string"
+                }
+            ]
+        },
+        "secret": "7640d59e15c5959e599ef437e3ba248d",
+        "updated_at": "2018-10-08T16:28:38Z",
+        "status": {
+            "status": "warning",
+            "messages": [
+                "You have disabled support for Accounts coming In and Out of this connector. Keep this in mind when debugging"
+            ],
+            "updated_at": "2018-10-08T16:32:56Z",
+            "name": "Tims Local Ngrok",
+            "id": "5bbb8592ec9ecaa580002cff"
+        },
+        "id": "5bbb8592ec9ecaa580002cff",
+        "picture": "https://d9bb86b5.ngrok.io/picture.png",
+        "homepage_url": "https://ad793dc7.hullapp.io/ships/5bbb8592ec9ecaa580002cff",
+        "manifest_url": "https://d9bb86b5.ngrok.io/manifest.json",
+        "created_at": "2018-10-08T16:28:04Z"
+    },
+    "channel": "user:update",
+    "messages": [
+        {
+            "user": {
+                "latest_session_initial_url": "https://hull-processor.herokuapp.com/admin.html?ship=5babcc36353acf92d90020ce&secret=44663b88fedfc2dc826f31dece7797d8&organization=ad793dc7.hullapp.io",
+                "latest_session_platform_id": "5babcc36353acf92d90020ce",
+                "first_session_initial_referrer": "https://dashboard.hullapp.io/ad793dc7/ships/5babcc36353acf92d90020ce/overview/Y29kZSBlZGl0b3I=",
+                "first_seen_at": "2018-10-08T16:12:38Z",
+                "id": "5bbb81f6eb1887abb700295d",
+                "first_session_platform_id": "5babcc36353acf92d90020ce",
+                "signup_session_started_at": "2018-10-08T16:12:38Z",
+                "last_known_ip": "73.7.88.73",
+                "signup_session_initial_referrer": "https://dashboard.hullapp.io/ad793dc7/ships/5babcc36353acf92d90020ce/overview/Y29kZSBlZGl0b3I=",
+                "latest_session_initial_referrer": "https://dashboard.hullapp.io/ad793dc7/ships/5babcc36353acf92d90020ce/overview/Y29kZSBlZGl0b3I=",
+                "anonymous_ids": [
+                    "1537214665-f537a0e8-c475-4f92-921a-d2d441f78d06"
+                ],
+                "indexed_at": "2018-10-08T16:34:12Z",
+                "first_session_started_at": "2018-10-08T16:12:38Z",
+                "signup_session_platform_id": "5babcc36353acf92d90020ce",
+                "created_at": "2018-10-08T16:12:38Z",
+                "is_approved": false,
+                "signup_session_initial_url": "https://hull-processor.herokuapp.com/admin.html?ship=5babcc36353acf92d90020ce&secret=44663b88fedfc2dc826f31dece7797d8&organization=ad793dc7.hullapp.io",
+                "latest_session_started_at": "2018-10-08T16:12:38Z",
+                "last_seen_at": "2018-10-08T16:33:15Z",
+                "first_session_initial_url": "https://hull-processor.herokuapp.com/admin.html?ship=5babcc36353acf92d90020ce&secret=44663b88fedfc2dc826f31dece7797d8&organization=ad793dc7.hullapp.io",
+                "segment_ids": ["5ade25df4d257947aa001cd5"]
+            },
+            "changes": {
+                "is_new": false,
+                "user": {
+                    "last_seen_at": [
+                        "2018-10-08T16:12:38Z",
+                        "2018-10-08T16:33:15Z"
+                    ]
+                },
+                "account": {},
+                "segments": {},
+                "account_segments": {}
+            },
+            "account": {},
+            "segments": [
+                {
+                    "id": "5ade25df4d257947aa001cd5",
+                    "name": "Intercom Users",
+                    "updated_at": "2018-04-23T18:28:47Z",
+                    "type": "users_segment",
+                    "created_at": "2018-04-23T18:28:47Z"
+                }
+            ],
+            "events": [
+                {
+                    "properties": {},
+                    "event_id": "5bbb86cbec9eca9f72002de5",
+                    "user_id": "5bbb81f6eb1887abb700295d",
+                    "event_source": "track",
+                    "app_name": "Processor",
+                    "event": "page",
+                    "event_type": "page",
+                    "track_id": "5bbb86cbec9eca9f72002de5",
+                    "context": {
+                        "useragent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Safari/537.36",
+                        "device": {
+                            "name": "Other"
+                        },
+                        "referrer": {
+                            "url": "https://dashboard.hullapp.io/ad793dc7/ships/5babcc36353acf92d90020ce/overview/Y29kZSBlZGl0b3I=",
+                            "host": "dashboard.hullapp.io",
+                            "path": "/ad793dc7/ships/5babcc36353acf92d90020ce/overview/Y29kZSBlZGl0b3I=",
+                            "campaign": {
+                                "term": null,
+                                "medium": null,
+                                "name": null,
+                                "content": null,
+                                "source": null
+                            }
+                        },
+                        "os": {
+                            "name": "Mac OS X",
+                            "version": "10.13.6"
+                        },
+                        "browser": {
+                            "major": 69,
+                            "name": "Chrome",
+                            "version": "69.0.3497"
+                        },
+                        "location": {
+                            "country": "US",
+                            "city": "Atlanta",
+                            "timezone": "America/New_York",
+                            "longitude": -84.3847,
+                            "latitude": 33.8379,
+                            "region": "GA",
+                            "countryname": "United States",
+                            "regionname": "Georgia",
+                            "zipcode": "30305"
+                        },
+                        "campaign": {
+                            "term": null,
+                            "medium": null,
+                            "name": null,
+                            "content": null,
+                            "source": null
+                        },
+                        "ip": "73.7.88.73",
+                        "page": {
+                            "url": "https://hull-processor.herokuapp.com/admin.html?ship=5babcc36353acf92d90020ce&secret=44663b88fedfc2dc826f31dece7797d8&organization=ad793dc7.hullapp.io",
+                            "host": "hull-processor.herokuapp.com",
+                            "path": "/admin.html"
+                        }
+                    },
+                    "anonymous_id": "1537214665-f537a0e8-c475-4f92-921a-d2d441f78d06",
+                    "ship_id": null,
+                    "created_at": "2018-10-08 16:33:15 UTC",
+                    "session_id": "1539015158-cdd0d00e-648a-4487-a24b-49420c9c3512",
+                    "app_id": "5babcc36353acf92d90020ce"
+                }
+            ],
+            "account_segments": [],
+            "message_id": "c5f98897cc20892e67c8cea9f693634a9f182be6"
+        }
+    ],
+    "accounts_segments": [],
+    "segments": [
+        {
+            "id": "5ade25df4d257947aa001cd5",
+            "updated_at": "2018-04-23T18:28:47Z",
+            "created_at": "2018-04-23T18:28:47Z",
+            "name": "Intercom Users",
+            "type": "users_segment",
+            "stats": {}
+        }
+    ]
+}

--- a/tests/helper/analytics-client-mock.js
+++ b/tests/helper/analytics-client-mock.js
@@ -1,0 +1,24 @@
+const Promise = require("bluebird");
+
+class ClientMock {
+  constructor() {
+    this.configuration = { secret: "topsecret123" };
+    this.logger = {
+      info: jest.fn((msg, data) => console.log(msg, data)),
+      debug: jest.fn((msg, data) => console.log(msg, data)),
+      error: jest.fn((msg, data) => console.log(msg, data)),
+      warn: jest.fn((msg, data) => console.log(msg, data)),
+      log: jest.fn((msg, data) => console.log(msg, data))
+    };
+    this.get = jest.fn(() => Promise.resolve());
+    this.post = jest.fn(() => Promise.resolve());
+    this.put = jest.fn(() => Promise.resolve());
+    this.traits = jest.fn(() => Promise.resolve());
+    this.track = jest.fn(() => Promise.resolve());
+    this.asUser = jest.fn(() => this);
+    this.asAccount = jest.fn(() => this);
+    this.account = jest.fn(() => this);
+  }
+}
+
+module.exports = { ClientMock };

--- a/tests/helper/client-mock.js
+++ b/tests/helper/client-mock.js
@@ -1,0 +1,25 @@
+import simpleMock from "simple-mock";
+
+const Promise = require("bluebird");
+
+class ClientMock {
+  constructor() {
+    this.configuration = { secret: "topsecret123" };
+    this.logger = {};
+    simpleMock.mock(this.logger, "info").callFn((msg, data) => console.log(msg, data));
+    simpleMock.mock(this.logger, "debug").callFn((msg, data) => console.log(msg, data));
+    simpleMock.mock(this.logger, "error").callFn((msg, data) => console.log(msg, data));
+    simpleMock.mock(this.logger, "warn").callFn((msg, data) => console.log(msg, data));
+    simpleMock.mock(this.logger, "log").callFn((msg, data) => console.log(msg, data));
+
+    simpleMock.mock(this, "get").callFn(() => Promise.resolve());
+    simpleMock.mock(this, "post").callFn(() => Promise.resolve());
+    simpleMock.mock(this, "put").callFn(() => Promise.resolve());
+    simpleMock.mock(this, "traits").callFn(() => Promise.resolve());
+    simpleMock.mock(this, "asUser").callFn(() => this);
+    simpleMock.mock(this, "asAccount").callFn(() => this);
+    simpleMock.mock(this, "account").callFn(() => this);
+  }
+}
+
+module.exports = { ClientMock };

--- a/tests/helper/connector-mock.js
+++ b/tests/helper/connector-mock.js
@@ -1,0 +1,33 @@
+import simpleMock from "simple-mock";
+
+const { ClientMock } = require("./client-mock");
+
+class ConnectorMock {
+  constructor(id = "1234", settings = {}, private_settings = {}) {
+    this.id = id;
+    this.settings = settings;
+    this.private_settings = private_settings;
+  }
+}
+
+class ContextMock {
+  constructor(id = "1234", settings = {}, private_settings = {}) {
+    this.ship = new ConnectorMock(id, settings, private_settings);
+    this.connector = new ConnectorMock(id, settings, private_settings);
+    this.client = new ClientMock();
+
+    this.metric = {};
+    simpleMock.mock(this.metric, "increment").callFn((name, value) => console.log(name, value));
+    simpleMock.mock(this.metric, "value").callFn((name, value) => console.log(name, value));
+
+    this.cache = {};
+    simpleMock.mock(this.cache, "wrap").callFn((key, cb) => Promise.resolve(cb));
+    simpleMock.mock(this.cache, "get").callFn(() => Promise.resolve());
+    simpleMock.mock(this.cache, "set").callFn(() => Promise.resolve());
+
+    this.helpers = {};
+    simpleMock.mock(this.helpers, "updateSettings").callFn(() => Promise.resolve(this.connector));
+  }
+}
+
+module.exports = { ConnectorMock, ContextMock };


### PR DESCRIPTION
I don't like to have to take up too many people's time, but I'm still a noob.

I've included:
@michaloo Because he's my connector spirit guide
@unity Because he's the segment connector guide, so he can tell me if I'm crazy or if we should do it a completely different way
@sbellity Because we specifically talked about this

This Pull Request:

Things I like:
1. I like the simplicity of the fix, which was to move the segment detection logic out of the if block for attribute change detection

Things I don't like:
1. I could not copy the existing testing pattern because in order to pass the scheduler payload all the way to the right logic, I would have to commit security tokens and all the rest of the things that an internal smart-notify requests needs
2. I introduced yet another testing library (simple-mock).  I briefly entertained trying to convert everything to jest, but that would involve a completely different way of running a test, so would like to get others buy in before I made that bigger change
3. The biggest thing that I don't like is that we've got so many testing patterns.  It's like a framework for each connector.  They've all got their good and bad things about them, but the biggest bad thing is that it's different for ALL of them.  Mono-repo is a good step in the right direction