### PR TITLE
Hotfix/prevent unwanted account link

### DIFF
--- a/server/update-user.js
+++ b/server/update-user.js
@@ -128,9 +128,19 @@ export default function updateUserFactory(analyticsClient) {
           if (!_.isEmpty(accountTraits)) {
             hull.logger.debug("group.send", { groupId: accountId, traits: accountTraits, context });
             analytics.group({ groupId: accountId, anonymousId, userId, traits: accountTraits, context, integrations });
+            asUser.account().logger.info("outgoing.account.success", { groupId: accountId, traits: accountTraits, context });
+          } else {
+            asUser.account().logger.info("outgoing.account.skip", { reason: "Empty traits payload", groupId: accountId, traits: accountTraits, context });
           }
-
-          asUser.account().logger.info("outgoing.account.success", { groupId: accountId, traits: accountTraits, context });
+        } else {
+          asUser.account().logger.info("outgoing.account.skip", {
+            reason: "doesn't match rules for sending",
+            handle_groups,
+            handle_accounts,
+            groupId,
+            accountId,
+            publicAccountIdField
+          });
         }
       } catch (err) {
         console.warn("Error processing group update", err);

--- a/server/update-user.js
+++ b/server/update-user.js
@@ -130,7 +130,7 @@ export default function updateUserFactory(analyticsClient) {
             analytics.group({ groupId: accountId, anonymousId, userId, traits: accountTraits, context, integrations });
           }
 
-          asUser.account({ external_id: accountId }).logger.info("outgoing.account.success", { groupId: accountId, traits: accountTraits, context });
+          asUser.account().logger.info("outgoing.account.success", { groupId: accountId, traits: accountTraits, context });
         }
       } catch (err) {
         console.warn("Error processing group update", err);


### PR DESCRIPTION
It seems this line: 
```
asUser.account({ external_id: accountId }).logger.info("outgoing.account.success", { groupId: accountId, traits: accountTraits, context });
```
might introduce unwanted setting of the external ID to an account which doesn't have one yet.

This PR also ensure we log account skips properly