### PR TITLE
Hotfix/issue 117 do not call group for user batch updates

### DIFF
--- a/tests/fixtures/index.js
+++ b/tests/fixtures/index.js
@@ -6,4 +6,5 @@ module.exports = {
   screen: require('./screen.json'),
   track: require('./track.json'),
   userUpdateEventPayload: require('./user-update-event-payload.json'),
+  userBatchUpdateEventPayload: require('./user-batchupdate-event-payload.json'),
 };

--- a/tests/fixtures/user-batchupdate-event-payload.json
+++ b/tests/fixtures/user-batchupdate-event-payload.json
@@ -8,8 +8,12 @@
     "connector": {
         "tags": [],
         "source_url": "https://d9bb86b5.ngrok.io/",
-        "private_settings": {"synchronized_segments": [
+        "private_settings": {
+          "synchronized_segments": [
             "5ade25df4d257947aa001cd5"
+        ],
+          "synchronized_properties": [
+            "last_seen_at"
         ]},
         "index": "https://d9bb86b5.ngrok.io/ship.js",
         "name": "Tims Local Ngrok",
@@ -18,7 +22,7 @@
             "public_id_field": "external_id",
             "handle_pages": true,
             "handle_screens": true,
-            "handle_accounts": false,
+            "handle_accounts": true,
             "ignore_segment_userId": false,
             "public_account_id_field": "external_id",
             "handle_groups": false,
@@ -277,7 +281,12 @@
                 "segments": {},
                 "account_segments": {}
             },
-            "account": {},
+            "account": {
+                "id": "5bd329d4e2bcf3eeaf000078",
+                "name": "darksideinc.com",
+                "domain": "darksideinc.com",
+                "external_id": "someid"
+            },
             "segments": [
                 {
                     "id": "5ade25df4d257947aa001cd5",
@@ -285,74 +294,6 @@
                     "updated_at": "2018-04-23T18:28:47Z",
                     "type": "users_segment",
                     "created_at": "2018-04-23T18:28:47Z"
-                }
-            ],
-            "events": [
-                {
-                    "properties": {},
-                    "event_id": "5bbb86cbec9eca9f72002de5",
-                    "user_id": "5bbb81f6eb1887abb700295d",
-                    "event_source": "track",
-                    "app_name": "Processor",
-                    "event": "page",
-                    "event_type": "page",
-                    "track_id": "5bbb86cbec9eca9f72002de5",
-                    "context": {
-                        "useragent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Safari/537.36",
-                        "device": {
-                            "name": "Other"
-                        },
-                        "referrer": {
-                            "url": "https://dashboard.hullapp.io/ad793dc7/ships/5babcc36353acf92d90020ce/overview/Y29kZSBlZGl0b3I=",
-                            "host": "dashboard.hullapp.io",
-                            "path": "/ad793dc7/ships/5babcc36353acf92d90020ce/overview/Y29kZSBlZGl0b3I=",
-                            "campaign": {
-                                "term": null,
-                                "medium": null,
-                                "name": null,
-                                "content": null,
-                                "source": null
-                            }
-                        },
-                        "os": {
-                            "name": "Mac OS X",
-                            "version": "10.13.6"
-                        },
-                        "browser": {
-                            "major": 69,
-                            "name": "Chrome",
-                            "version": "69.0.3497"
-                        },
-                        "location": {
-                            "country": "US",
-                            "city": "Atlanta",
-                            "timezone": "America/New_York",
-                            "longitude": -84.3847,
-                            "latitude": 33.8379,
-                            "region": "GA",
-                            "countryname": "United States",
-                            "regionname": "Georgia",
-                            "zipcode": "30305"
-                        },
-                        "campaign": {
-                            "term": null,
-                            "medium": null,
-                            "name": null,
-                            "content": null,
-                            "source": null
-                        },
-                        "ip": "73.7.88.73",
-                        "page": {
-                            "url": "https://hull-processor.herokuapp.com/admin.html?ship=5babcc36353acf92d90020ce&secret=44663b88fedfc2dc826f31dece7797d8&organization=ad793dc7.hullapp.io",
-                            "host": "hull-processor.herokuapp.com",
-                            "path": "/admin.html"
-                        }
-                    },
-                    "anonymous_id": "1537214665-f537a0e8-c475-4f92-921a-d2d441f78d06",
-                    "ship_id": null,
-                    "created_at": "2018-10-08 16:33:15 UTC",
-                    "session_id": "1539015158-cdd0d00e-648a-4487-a24b-49420c9c3512",
-                    "app_id": "5babcc36353acf92d90020ce"
                 }
             ],
             "account_segments": [],

--- a/tests/segment-tests.js
+++ b/tests/segment-tests.js
@@ -439,76 +439,76 @@ describe("Segment Ship", () => {
   });
 
   describe("Outgoing User Update Messages", () => {
-    // it("Event sent in User Update - Not in Segment", (done) => {
-    //   const ctxMock = new ContextMock();
-    //   ctxMock.ship = userUpdateEventPayload.connector;
-    //   ctxMock.connector = userUpdateEventPayload.connector;
-    //
-    //   const message = userUpdateEventPayload.messages[0];
-    //
-    //   const analytics = {
-    //     group: () => {},
-    //     enqueue: () => {},
-    //     page: () => {},
-    //     track: () => {},
-    //     identify: () => true,
-    //   };
-    //
-    //   sinon.spy(analytics, "group");
-    //   sinon.spy(analytics, "enqueue");
-    //   sinon.spy(analytics, "page");
-    //   sinon.spy(analytics, "track");
-    //   sinon.spy(analytics, "identify");
-    //
-    //   const analyticsClient = () => analytics;
-    //
-    //   const updateUserFunction = updateUser(analyticsClient);
-    //   const updatedAttributes = updateUserFunction(
-    //     {
-    //       message
-    //     },
-    //     {
-    //       ship: ctxMock.ship,
-    //       hull: ctxMock.client
-    //     }
-    //   );
-    //
-    //   const infoLogMock = ctxMock.client.logger.info;
-    //
-    //   // In this first scenario, the user is in the segment we're synchronizing
-    //   // But because there are no attribute updates, so we return false
-    //   // But in this case, it's an event incoming not an attribute, so we still get a successful outgoing event
-    //   assert(updatedAttributes === false);
-    //   assert(analytics.page.getCalls().length === 1);
-    //   assert(analytics.track.getCalls().length === 0);
-    //   assert(analytics.group.getCalls().length === 0);
-    //   assert(analytics.identify.getCalls().length === 0);
-    //   assert(infoLogMock.getCalls()[infoLogMock.getCalls().length - 1].args[0] === "outgoing.event.success");
-    //   assert(infoLogMock.getCalls()[infoLogMock.getCalls().length - 2].args[0] === "outgoing.user.skip");
-    //
-    //   ctxMock.ship.private_settings.synchronized_segments = ["notarealsegment"];
-    //
-    //   const updatedAttributes2 = updateUserFunction(
-    //     {
-    //       message
-    //     },
-    //     {
-    //       ship: ctxMock.ship,
-    //       hull: ctxMock.client
-    //     }
-    //   );
-    //
-    //   // In this second scenario, we set the synchronized segment to be different than the one the user is in
-    //   // We still get false because no attribute updates
-    //   // But now we also skip anything having to do with the user
-    //   assert(updatedAttributes2 === false);
-    //   assert(analytics.page.getCalls().length === 1);
-    //   assert(analytics.track.getCalls().length === 0);
-    //   assert(analytics.group.getCalls().length === 0);
-    //   assert(analytics.identify.getCalls().length === 0);
-    //   assert(infoLogMock.getCalls()[infoLogMock.getCalls().length - 1].args[0] === "outgoing.user.skip");
-    //   done();
-    // });
+    it("Event sent in User Update - Not in Segment", (done) => {
+      const ctxMock = new ContextMock();
+      ctxMock.ship = userUpdateEventPayload.connector;
+      ctxMock.connector = userUpdateEventPayload.connector;
+
+      const message = userUpdateEventPayload.messages[0];
+
+      const analytics = {
+        group: () => {},
+        enqueue: () => {},
+        page: () => {},
+        track: () => {},
+        identify: () => true,
+      };
+
+      sinon.spy(analytics, "group");
+      sinon.spy(analytics, "enqueue");
+      sinon.spy(analytics, "page");
+      sinon.spy(analytics, "track");
+      sinon.spy(analytics, "identify");
+
+      const analyticsClient = () => analytics;
+
+      const updateUserFunction = updateUser(analyticsClient);
+      const updatedAttributes = updateUserFunction(
+        {
+          message
+        },
+        {
+          ship: ctxMock.ship,
+          hull: ctxMock.client
+        }
+      );
+
+      const infoLogMock = ctxMock.client.logger.info;
+
+      // In this first scenario, the user is in the segment we're synchronizing
+      // But because there are no attribute updates, so we return false
+      // But in this case, it's an event incoming not an attribute, so we still get a successful outgoing event
+      assert(updatedAttributes === false);
+      assert(analytics.page.getCalls().length === 1);
+      assert(analytics.track.getCalls().length === 0);
+      assert(analytics.group.getCalls().length === 0);
+      assert(analytics.identify.getCalls().length === 0);
+      assert(infoLogMock.getCalls()[infoLogMock.getCalls().length - 1].args[0] === "outgoing.event.success");
+      assert(infoLogMock.getCalls()[infoLogMock.getCalls().length - 2].args[0] === "outgoing.user.skip");
+
+      ctxMock.ship.private_settings.synchronized_segments = ["notarealsegment"];
+
+      const updatedAttributes2 = updateUserFunction(
+        {
+          message
+        },
+        {
+          ship: ctxMock.ship,
+          hull: ctxMock.client
+        }
+      );
+
+      // In this second scenario, we set the synchronized segment to be different than the one the user is in
+      // We still get false because no attribute updates
+      // But now we also skip anything having to do with the user
+      assert(updatedAttributes2 === false);
+      assert(analytics.page.getCalls().length === 1);
+      assert(analytics.track.getCalls().length === 0);
+      assert(analytics.group.getCalls().length === 0);
+      assert(analytics.identify.getCalls().length === 0);
+      assert(infoLogMock.getCalls()[infoLogMock.getCalls().length - 1].args[0] === "outgoing.user.skip");
+      done();
+    });
 
     it("Event sent in User Update - Simulated batch call, no group", (done) => {
       const ctxMock = new ContextMock();


### PR DESCRIPTION
Will only call group if ignoreFilters is false.  ignoreFilters is synonymous with "BATCH" and we don't want to call group if we have a batch call.

this ignoreFilters and !ignoreFilters is starting to get scary...  I added a bunch of comments to clarify, but probably should refactor soon... Romain's new branch maybe?